### PR TITLE
feat(ai): add core chunk / embed / save utilities

### DIFF
--- a/apps/web/app/api/ai/chat/route.ts
+++ b/apps/web/app/api/ai/chat/route.ts
@@ -1,0 +1,49 @@
+import { supabase } from "@mwsp-academy/ai";
+import OpenAI from "openai";
+import { NextRequest } from "next/server";
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { question, courseId } = body as {
+    question: string;
+    courseId?: string;
+  };
+  if (!question) return new Response("Missing question", { status: 400 });
+
+  // 1. Embed question and find 4 relevant chunks for context.
+  const {
+    data: [embed],
+  } = await openai.embeddings.create({
+    input: question,
+    model: "text-embedding-3-small",
+  });
+  const { data: matches } = await supabase.rpc("match_ai_chunks", {
+    query_embedding: embed.embedding,
+    match_threshold: 0.8,
+    match_count: 4,
+    course_filter: courseId ?? null,
+  });
+  const context = matches?.map((m: any) => m.content).join("\n\n") ?? "";
+
+  // 2. Chat completion with context
+  const completion = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    stream: false,
+    messages: [
+      {
+        role: "system",
+        content:
+          "You are an AI coach for MSP Academy. Use the provided context to answer the user question. If unsure, say you don't know.",
+      },
+      { role: "system", content: `CONTEXT:\n${context}` },
+      { role: "user", content: question },
+    ],
+  });
+
+  return Response.json({
+    answer: completion.choices[0].message.content,
+    sources: matches?.map((m: any) => ({ id: m.id, source: m.source })) ?? [],
+  });
+}

--- a/apps/web/app/api/ai/search/route.ts
+++ b/apps/web/app/api/ai/search/route.ts
@@ -1,0 +1,30 @@
+import { supabase } from "@mwsp-academy/ai";
+import { NextRequest } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const query = req.nextUrl.searchParams.get("q") || "";
+  if (!query) return new Response("Missing q", { status: 400 });
+
+  // 1. Embed the query with OpenAI (same model as chunks)
+  const { default: OpenAI } = await import("openai");
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const {
+    data: [embed],
+  } = await openai.embeddings.create({
+    input: query,
+    model: "text-embedding-3-small",
+  });
+
+  // 2. Vector similarity search via rpc function (cosine distance)
+  const { data, error } = await supabase.rpc("match_ai_chunks", {
+    query_embedding: embed.embedding,
+    match_threshold: 0.8,
+    match_count: 5,
+  });
+  if (error) {
+    console.error(error);
+    return new Response("Search error", { status: 500 });
+  }
+
+  return Response.json({ results: data });
+}

--- a/apps/web/app/api/webhooks/mux/route.ts
+++ b/apps/web/app/api/webhooks/mux/route.ts
@@ -1,0 +1,38 @@
+import type { NextRequest } from "next/server";
+import { ingestMuxAsset } from "@mwsp-academy/ai/mux";
+
+/**
+ * Mux sends a webhook when an asset is ready. Body example:
+ * {
+ *   "type": "video.asset.static_renditions.ready",
+ *   "data": {
+ *     "id": "MUX_ASSET_ID",
+ *     "passthrough": "courseId:PLAYBOOK_TYPE" // we store metadata here
+ *   }
+ * }
+ */
+export async function POST(req: NextRequest) {
+  const payload = await req.json();
+  const event = payload?.type;
+
+  if (event !== "video.asset.static_renditions.ready") {
+    return Response.json({ ok: true }); // ignore other events
+  }
+
+  const asset = payload.data;
+  const passthrough = asset?.passthrough as string | undefined;
+  if (!passthrough) {
+    console.warn("Mux webhook missing passthrough metadata");
+    return Response.json({ ok: false });
+  }
+
+  // Parse passthrough -> "courseId:PLAYBOOK_TYPE"
+  const [courseId, playbookType] = passthrough.split(":");
+  try {
+    await ingestMuxAsset(asset.id, courseId, playbookType.toUpperCase());
+    return Response.json({ ok: true });
+  } catch (err: any) {
+    console.error("Mux ingest failed", err);
+    return new Response("Error", { status: 500 });
+  }
+}

--- a/packages/ai/index.ts
+++ b/packages/ai/index.ts
@@ -1,0 +1,99 @@
+import { createClient } from "@supabase/supabase-js";
+import OpenAI from "openai";
+
+// --- ENV -------------------------------------------------------------------
+const {
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE,
+  OPENAI_API_KEY,
+} = process.env;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+  throw new Error("Missing Supabase env vars");
+}
+if (!OPENAI_API_KEY) {
+  throw new Error("Missing OPENAI_API_KEY");
+}
+
+// --- Clients ----------------------------------------------------------------
+export const supabase = createClient(
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE,
+  {
+    auth: { persistSession: false },
+    db: { schema: "public" },
+  }
+);
+
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+
+// --- Helpers ----------------------------------------------------------------
+export interface Chunk {
+  content: string;
+  tokenCount: number;
+}
+
+/**
+ * Very naive token estimator (4 chars ~ 1 token). Good enough for chunking.
+ */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Splits text into ~500-token chunks (max 800 to leave room for metadata).
+ */
+export function chunkText(text: string, maxTokens = 500): Chunk[] {
+  const sentences = text.split(/(?<=[.!?])\s+/);
+  const chunks: Chunk[] = [];
+  let buffer = "";
+
+  for (const sentence of sentences) {
+    const next = buffer ? `${buffer} ${sentence}` : sentence;
+    if (estimateTokens(next) > maxTokens && buffer) {
+      chunks.push({ content: buffer, tokenCount: estimateTokens(buffer) });
+      buffer = sentence; // start new buffer
+    } else {
+      buffer = next;
+    }
+  }
+  if (buffer) {
+    chunks.push({ content: buffer, tokenCount: estimateTokens(buffer) });
+  }
+  return chunks;
+}
+
+/**
+ * Creates embeddings for a batch of chunks using OpenAI.
+ */
+export async function embedChunks(chunks: Chunk[]): Promise<Float32Array[]> {
+  const texts = chunks.map((c) => c.content);
+  const { data } = await openai.embeddings.create({
+    input: texts,
+    model: "text-embedding-3-small",
+  });
+  return data.map((d) => new Float32Array(d.embedding));
+}
+
+/**
+ * Persists chunks + embeddings to Supabase `AiChunk`.
+ */
+export async function saveChunks(
+  courseId: string,
+  playbookType: string,
+  source: "video" | "workbook" | "transcript",
+  chunks: Chunk[],
+  embeddings: Float32Array[]
+) {
+  const rows = chunks.map((c, idx) => ({
+    course_id: courseId,
+    playbook_type: playbookType,
+    source,
+    content: c.content,
+    token_count: c.tokenCount,
+    embedding: embeddings[idx],
+  }));
+
+  const { error } = await supabase.from("AiChunk").insert(rows);
+  if (error) throw error;
+}

--- a/packages/ai/mux.ts
+++ b/packages/ai/mux.ts
@@ -1,0 +1,28 @@
+import { Chunk, chunkText, embedChunks, saveChunks } from "./index";
+import { supabase } from "./index";
+import fetch from "node-fetch";
+
+// Minimal Mux transcript fetcher + ingestion helper
+export async function ingestMuxAsset(
+  muxAssetId: string,
+  courseId: string,
+  playbookType: string
+) {
+  // 1. Fetch transcript from Mux (example URL, assumes WebVTT stored)
+  const url = `https://stream.mux.com/${muxAssetId}.vtt`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch transcript: ${res.status}`);
+  const vtt = await res.text();
+  const plain = vtt
+    .split(/\n\n/)
+    .filter((block) => !/^\d+$/.test(block.trim())) // remove cue numbers
+    .map((b) => b.replace(/^[\d:\.\-, ]+\n/, "")) // remove timestamps
+    .join(" ")
+    .replace(/<[^>]+>/g, "") // strip tags
+    .trim();
+
+  // 2. Chunk, embed, save
+  const chunks: Chunk[] = chunkText(plain);
+  const embeddings = await embedChunks(chunks);
+  await saveChunks(courseId, playbookType, "transcript", chunks, embeddings);
+}


### PR DESCRIPTION
### What’s inside
• packages/ai/index.ts  
  – [chunkText](cci:1://file:///Users/mackmother/mwsp-academy/packages/ai/index.ts:42:0-63:1) → splits text into ~500-token chunks  
  – [embedChunks](cci:1://file:///Users/mackmother/mwsp-academy/packages/ai/index.ts:65:0-75:1) → batch-embeds using OpenAI `text-embedding-3-small`  
  – [saveChunks](cci:1://file:///Users/mackmother/mwsp-academy/packages/ai/index.ts:77:0-98:1) → writes chunks + embeddings to Supabase `AiChunk`  
  – Lightweight token estimator + initialized Supabase/OpenAI clients.

### Why
Forms the foundation of the AI ingestion pipeline.  
Next commits on this branch will:
1. Add Mux webhook to fetch transcripts and call these helpers.  
2. Create `/api/ai/search` and `/api/ai/chat` endpoints.  

Merging early lets us review the utility code separately and keeps the diff small.