### PR TITLE
chore: pin pnpm@9.1.0 and set Node ≥18.17 for Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
   "license": "ISC",
   "description": "",
   "private": true,
-  "packageManager": "pnpm@9",
+  "packageManager": "pnpm@9.1.0",
+  "engines": {
+    "node": ">=18.17"
+  },
   "workspaces": [
     "apps/*",
     "packages/*"


### PR DESCRIPTION
This patch fixes the Vercel “npm matches” install error by:
• Updating root 
package.json
 to "packageManager": "pnpm@9.1.0"
• Adding "engines": { "node": \">=18.17\" } for clarity

No functional code changes—just build configuration to ensure CI/CD succeeds.