### PR TITLE
feat(web): initial landing page hero & features grid

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,11 @@
+import Hero from "../components/landing/Hero";
+import FeaturesGrid from "../components/landing/FeaturesGrid";
+
 export default function Home() {
   return (
-    <main className="flex items-center justify-center h-screen">
-      <h1 className="text-4xl font-bold">MwSP Academy</h1>
-    </main>
+    <>
+      <Hero />
+      <FeaturesGrid />
+    </>
   );
 }

--- a/apps/web/components/landing/FeaturesGrid.tsx
+++ b/apps/web/components/landing/FeaturesGrid.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { ReactNode } from "react";
+
+interface FeatureProps {
+  icon: ReactNode;
+  title: string;
+  description: string;
+}
+
+function Feature({ icon, title, description }: FeatureProps) {
+  return (
+    <div className="flex flex-col items-center text-center p-6">
+      <div className="text-4xl mb-4 text-[#F6B352]">{icon}</div>
+      <h3 className="text-lg font-semibold mb-2 text-white">{title}</h3>
+      <p className="text-sm text-gray-300 max-w-xs">{description}</p>
+    </div>
+  );
+}
+
+export default function FeaturesGrid() {
+  const features: FeatureProps[] = [
+    {
+      icon: "🎯",
+      title: "Actionable Playbooks",
+      description: "Step-by-step guides proven to grow recurring revenue for MSPs.",
+    },
+    {
+      icon: "📈",
+      title: "Expert Instructors",
+      description: "Learn directly from industry leaders who have scaled multi-million-dollar MSPs.",
+    },
+    {
+      icon: "⚡️",
+      title: "Bite-Size Lessons",
+      description: "Netflix-style episodes you can binge or watch on the go.",
+    },
+  ];
+
+  return (
+    <section className="bg-[#1F2124] py-16">
+      <div className="max-w-6xl mx-auto grid grid-cols-1 sm:grid-cols-3 gap-8 px-6">
+        {features.map((f) => (
+          <Feature key={f.title} {...f} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/landing/Hero.tsx
+++ b/apps/web/components/landing/Hero.tsx
@@ -1,0 +1,43 @@
+"use client";
+import Image from "next/image";
+import Link from "next/link";
+
+export default function Hero() {
+  return (
+    <section className="relative flex flex-col items-center justify-center w-full h-[70vh] bg-gradient-to-b from-[#1F2124] to-[#383A3F] text-white overflow-hidden">
+      {/* Logo */}
+      <div className="flex items-center gap-3 mb-6">
+        <Image
+          src="/logo.png" // TODO: replace with optimized logo path
+          alt="MwSP Academy logo"
+          width={180}
+          height={42}
+          priority
+        />
+      </div>
+      {/* Headline */}
+      <h1 className="text-4xl md:text-6xl font-extrabold text-center max-w-4xl leading-tight">
+        Level-up Your MSP with <span className="text-[#F6B352]">World-Class</span> Playbooks & Courses
+      </h1>
+      {/* CTA buttons */}
+      <div className="mt-8 flex gap-4">
+        <Link
+          href="/browse"
+          className="px-6 py-3 rounded-md bg-[#F6B352] text-black font-semibold hover:opacity-90 transition"
+        >
+          Browse Courses
+        </Link>
+        <Link
+          href="/api/auth/login"
+          className="px-6 py-3 rounded-md border border-white font-semibold hover:bg-white hover:text-black transition"
+        >
+          Sign In
+        </Link>
+      </div>
+      {/* Subtle background flair */}
+      <div className="absolute inset-0 pointer-events-none">
+        <div className="absolute -bottom-32 left-1/2 -translate-x-1/2 w-[120%] h-[120%] bg-[#F68657] opacity-10 blur-3xl rounded-full" />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Adds the first slice of the Netflix-style landing page:
• Hero section with dark gradient, brand logo, bold headline, and gold CTAs.
• Features grid highlighting actionable playbooks, expert instructors, and binge-able lessons.
Tailwind palette aligns with #F6B352 (gold) / #383A3F / #1F2124.
Next steps (future PRs): course carousel, pricing strip, testimonials, footer.

After pushing, GitHub will show a Vercel preview URL so you can see the “pretty picture.” Drop in any copy/image tweaks and we’ll iterate.