### PR TITLE
feat(web): polished hero & playbook carousel

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,11 +1,13 @@
 import Hero from "../components/landing/Hero";
 import FeaturesGrid from "../components/landing/FeaturesGrid";
+import PlaybookCarousel from "../components/landing/PlaybookCarousel";
 
 export default function Home() {
   return (
     <>
       <Hero />
       <FeaturesGrid />
+      <PlaybookCarousel />
     </>
   );
 }

--- a/apps/web/components/landing/Hero.tsx
+++ b/apps/web/components/landing/Hero.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 
 export default function Hero() {
   return (
-    <section className="relative flex flex-col items-center justify-center w-full h-[70vh] bg-gradient-to-b from-[#1F2124] to-[#383A3F] text-white overflow-hidden">
+    <section className="relative flex flex-col items-center justify-center w-full h-screen bg-gradient-to-b from-brand-dark2 to-brand-dark1 text-white overflow-hidden">
       {/* Logo */}
       <div className="flex items-center gap-3 mb-6">
         <Image
@@ -16,7 +16,7 @@ export default function Hero() {
         />
       </div>
       {/* Headline */}
-      <h1 className="text-4xl md:text-6xl font-extrabold text-center max-w-4xl leading-tight">
+      <h1 className="text-5xl md:text-7xl lg:text-8xl font-extrabold text-center max-w-4xl leading-tight">
         Level-up Your MSP with <span className="text-[#F6B352]">World-Class</span> Playbooks & Courses
       </h1>
       {/* CTA buttons */}
@@ -33,10 +33,6 @@ export default function Hero() {
         >
           Sign In
         </Link>
-      </div>
-      {/* Subtle background flair */}
-      <div className="absolute inset-0 pointer-events-none">
-        <div className="absolute -bottom-32 left-1/2 -translate-x-1/2 w-[120%] h-[120%] bg-[#F68657] opacity-10 blur-3xl rounded-full" />
       </div>
     </section>
   );

--- a/apps/web/components/landing/PlaybookCarousel.tsx
+++ b/apps/web/components/landing/PlaybookCarousel.tsx
@@ -1,0 +1,41 @@
+"use client";
+import Image from "next/image";
+
+const dummyCards = [
+  { title: "Sales Playbook", img: "/placeholder/course1.jpg" },
+  { title: "Marketing Playbook", img: "/placeholder/course2.jpg" },
+  { title: "Operations Playbook", img: "/placeholder/course3.jpg" },
+  { title: "Customer Success", img: "/placeholder/course4.jpg" },
+  { title: "Pricing Strategies", img: "/placeholder/course5.jpg" },
+];
+
+export default function PlaybookCarousel() {
+  return (
+    <section className="bg-brand-dark2 py-16">
+      <h2 className="text-3xl md:text-4xl font-bold text-white mb-8 text-center">
+        Popular Playbooks
+      </h2>
+      <div className="overflow-x-auto scrollbar-hide">
+        <div className="flex gap-6 px-6 md:px-10 w-max">
+          {dummyCards.map((c) => (
+            <div
+              key={c.title}
+              className="relative w-64 h-36 rounded-lg overflow-hidden shrink-0 group cursor-pointer"
+            >
+              <Image
+                src={c.img}
+                alt={c.title}
+                fill
+                className="object-cover transition-transform duration-300 group-hover:scale-105"
+              />
+              <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition" />
+              <span className="absolute bottom-3 left-3 text-white font-semibold text-sm">
+                {c.title}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
 Full-viewport hero with dark gradient, larger headline, balanced spacing, gold/white CTAs
• Added Popular Playbooks horizontal carousel (placeholder cards, Netflix-style hover zoom)
• Removed stray background div, fixed lints
• Uses brand palette tokens in Tailwind for easier theming

Let me know once it’s up—then I’ll proceed with testimonials, pricing, and footer.