### PR TITLE
Fix: Add placeholder.com domain to Next.js image configuration

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -12,6 +12,16 @@ const nextConfig = {
     // Skip TS errors during production build
     ignoreBuildErrors: true,
   },
+  // Configure external image domains
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'via.placeholder.com',
+        pathname: '/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This PR fixes the 400 Bad Request errors seen in the production environment for placeholder images. 

- Added via.placeholder.com to the remotePatterns in Next.js image configuration
- This should resolve the console errors for image loading

This may also help with styling issues if they are related to layout shifts caused by image loading failures.