### PR TITLE
Fix: Update build script to use npx for Tailwind CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "pnpm --filter web dev",
     "build": "pnpm --filter web build",
-    "build:web": "cd apps/web && NODE_ENV=production pnpm dlx tailwindcss -i ./app/globals.css -o ./app/output.css && pnpm build",
+    "build:web": "cd apps/web && NODE_ENV=production npx tailwindcss -i ./app/globals.css -o ./app/output.css && pnpm build",
     "lint": "eslint \"**/*.{ts,tsx,js,jsx}\"",
     "format": "prettier -w ."
   },


### PR DESCRIPTION
This PR fixes the Vercel build error "ERR_PNPM_DLX_NO_BIN No binaries found in tailwindcss" by:

- Changing the build:web script from using `pnpm dlx tailwindcss` to `npx tailwindcss`
- This ensures it uses the locally installed tailwindcss package instead of trying to download it temporarily

This should resolve the build failure and allow the deployment to complete successfully, hopefully fixing the styling issues that have been occurring in production.