### PR TITLE
Fix: Update build script to use pnpm exec for Tailwind CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "pnpm --filter web dev",
     "build": "pnpm --filter web build",
-    "build:web": "cd apps/web && NODE_ENV=production npx tailwindcss -i ./app/globals.css -o ./app/output.css && pnpm build",
+    "build:web": "cd apps/web && NODE_ENV=production pnpm exec tailwindcss -i ./app/globals.css -o ./app/output.css && pnpm build",
     "lint": "eslint \"**/*.{ts,tsx,js,jsx}\"",
     "format": "prettier -w ."
   },


### PR DESCRIPTION
This PR fixes the Vercel build error "npm error could not determine executable to run" by:

- Changing the build:web script to use `pnpm exec tailwindcss` instead of `npx tailwindcss`
- This ensures the correct binary is found in the pnpm workspace environment on Vercel

This should resolve the build failure and allow the deployment to complete successfully, hopefully fixing the styling issues that have been occurring in production.