### PR TITLE
Fix: Refactor build scripts for better monorepo structure

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build:css": "NODE_ENV=production tailwindcss -i ./app/globals.css -o ./app/output.css",
+    "build": "npm run build:css && next build",
     "dev:turbopack": "next dev --turbopack",
     "start": "next start",
     "lint": "next lint"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "pnpm --filter web dev",
     "build": "pnpm --filter web build",
-    "build:web": "cd apps/web && NODE_ENV=production pnpm exec tailwindcss -i ./app/globals.css -o ./app/output.css && pnpm build",
+    "build:web": "pnpm --filter web build",
     "lint": "eslint \"**/*.{ts,tsx,js,jsx}\"",
     "format": "prettier -w ."
   },


### PR DESCRIPTION
This PR improves the build process by:

1. Moving the Tailwind CSS build step directly into the web package:
   - Add a `build:css` script in apps/web/package.json
   - Update the web build script to run CSS build before Next.js build

2. Simplify the root package.json build scripts:
   - Change build:web to use the standard pnpm workspace filter syntax

These changes better follow monorepo best practices and should fix the Vercel deployment issues with Tailwind CSS.

### Important Vercel Settings
To ensure a successful build, please verify these Vercel settings:
- Root Directory: (leave blank - build from the repository root)
- Build Command: pnpm run build
- Output Directory: apps/web/.next