### PR TITLE
Fix: Use pnpm exec to find Tailwind CSS binary

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build:css": "NODE_ENV=production tailwindcss -i ./app/globals.css -o ./app/output.css",
-    "build": "npm run build:css && next build",
+    "build:css": "NODE_ENV=production pnpm exec tailwindcss -i ./app/globals.css -o ./app/output.css",
+    "build": "pnpm run build:css && next build",
     "dev:turbopack": "next dev --turbopack",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
This PR fixes the Vercel build error "tailwindcss: command not found" by:

1. Modifying the `build:css` script in apps/web/package.json to explicitly use 
   `pnpm exec tailwindcss` instead of just `tailwindcss`

2. Updating the `build` script to use `pnpm run build:css` instead of `npm run build:css` 
   for better pnpm workspace compatibility

These changes ensure that the Tailwind CSS binary is properly found within the 
pnpm package context during the Vercel build process.

The Vercel settings should remain:
- Root Directory: (leave blank)
- Build Command: pnpm run build
- Output Directory: apps/web/.next